### PR TITLE
Adding difficulties per problem, visible on challenges list.

### DIFF
--- a/challenges/junior.json
+++ b/challenges/junior.json
@@ -19,13 +19,13 @@
         "parameters": ["array"],
         "returns": "number",
         "examples": [{
-            "inputs": [[1, 5, 4, 1]],
+            "inputs": ["[1, 5, 4, 1]"],
             "output": "4"
         },{
-            "inputs": [[10, 14, 17, 9, 18]],
+            "inputs": ["[10, 14, 17, 9, 18]"],
             "output": "17"
         },{
-            "inputs": [[1, 2, 3, 5, 5]],
+            "inputs": ["[1, 2, 3, 5, 5]"],
             "output": "5"
         }]
     },

--- a/difficulty.json
+++ b/difficulty.json
@@ -1,0 +1,24 @@
+{
+    "generated": {
+        "method": "manual",
+        "timestamp": "2016-09-04T15:36:04+00:00"
+    },
+    "scores": {
+        "blackjack": 0.4,
+        "changemaker": 0.3,
+        "chemistry": 0.5,
+        "doubloon": 0.3,
+        "junior": 0.4,
+        "longx": 0.3,
+        "narcissistic": 0.6,
+        "nemo": 0.6,
+        "palindrome": 0.2,
+        "phonenum": 0.5,
+        "piglatin": 0.3,
+        "rosebud": 0.4,
+        "scatterpack": 0.6,
+        "slide": 0.6,
+        "statues": 0.7,
+        "weaver": 0.3
+    }
+}

--- a/src/pug/challenges.pug
+++ b/src/pug/challenges.pug
@@ -17,8 +17,17 @@ main
                 a(href='/challenges/' + challenge.spec.func) 
                     li 
                         div
-                            h3= challenge.name
-                            p= 'added by ' + challenge.added_by.name + ' on ' + challenge.added_on
+                            h3
+                                p.difficulty
+                                    each v in [0, 1, 2, 3]
+                                        if challenge.difficulty >= v
+                                            span.diff-yes &#9737;
+                                        else
+                                            span.diff-no &#9737;
+                            
+                                span= challenge.name
+
+                            p.source= 'added by ' + challenge.added_by.name + ' on ' + challenge.added_on
                         h4 #[code= challenge.spec.func] #[span= ' - ' + challenge.description.short]
 
 include ./partials/footer.pug

--- a/src/pug/partials/footer.pug
+++ b/src/pug/partials/footer.pug
@@ -1,2 +1,2 @@
 footer
-        p made by #[a(href="https://lukesegars.com") luke segars]. icon by sergey demushkin.
+        p challenges provided by the community. icon by sergey demushkin.

--- a/src/scss/partials/_challenge.scss
+++ b/src/scss/partials/_challenge.scss
@@ -44,17 +44,32 @@ main {
                 margin-bottom: 15px;
 
                 h3 {
-                    @include grid-column(8);
+                    @include grid-column(7);
 
                     margin: 0;
                     font-size: 1.25em;
+
+                    .difficulty {
+                        margin: 0 0.9em 0 0;
+                        display: inline-block;
+                        font-weight: 300;
+
+                        .diff-yes {
+                            color: black;
+                        }
+
+                        .diff-no {
+                            color: #ccc;
+                        }
+                    }
                 }
 
-                p {
-                    @include grid-column(4);
-                    margin: 0;
+                p.source {
+                    @include grid-column(3);
                     text-align: right;
                     font-size: 0.9em;
+                    
+                    margin: 0;
                     font-weight: 300;
                 }
 


### PR DESCRIPTION
Currently all manually specified, displayed using a 1-4 bucket visual. Individual problems are specified using their function name, which is already required to be unique.

The eventual goal is to fetch the difficulties data from another system that can do some logs analysis to try to heuristically determine difficulty. Setting aside how that will work for the time being, as long as we can get a JSON file containing a mapping between problems and their scores the process here should work fine.

One unknown: if we build static files only when changes are made to challenges or the codebase, the difficulties may not be updated regularly. Maybe have a nightly build and deploy process as well?